### PR TITLE
Add reference to packages.magento.com in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ The intent is to learn by example, following our best practices for developing a
 
 Each sample is packaged and available individually at packages.magento.com.  For convenience and demonstration of our bundling of modules, we have included the [sample-bundle-all](sample-bundle-all) composer metapackage.  Including this dependency in your Magento project is the more convenient way to integrate the full set of examples. Refer to that sample for more detailed installation instructions.
 
+In order to be able to install any of these samples you'll need to be sure that your root composer.json file contains a reference to the repository that holds them.  To do so you'll need to add the following to `composer.json`:
+
+```json
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "http://packages.magento.com/"
+        }
+    ]
+```
+
 ## Contributors
 
 Magento Core team

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ In order to be able to install any of these samples you'll need to be sure that 
     ]
 ```
 
+The above can also be added via the composer cli with the command: 
+
+    composer config repositories.magento composer http://packages.magento.com/
+
 ## Contributors
 
 Magento Core team


### PR DESCRIPTION
Update the readme to make sure everyone knows that the packages.magento.com repository needs to be defined in the root composer.json file.  This is important for anyone trying to add these samples to a clone of the development repository instead of a production project.

Related to #26 