### PR TITLE
Update sample-module-newpage to use echotag

### DIFF
--- a/sample-module-newpage/view/frontend/templates/main.phtml
+++ b/sample-module-newpage/view/frontend/templates/main.phtml
@@ -4,4 +4,4 @@
  * See COPYING.txt for license details.
  */
 ?>
-<p><?php echo 'Hello world!'?></p>
+<p><?= 'Hello world!' ?></p>


### PR DESCRIPTION
Magento 2 requires at least PHP 5.4, so there is no reason not to use the less verbose, cleaner, simpler, etc. echotag.  It cannot be disabled in PHP configuration in situations where Magento 2 can run.