### PR TITLE
Update version numbers for Magento 2 dependencies

### DIFF
--- a/sample-module-interception/composer.json
+++ b/sample-module-interception/composer.json
@@ -10,7 +10,7 @@
   "require": {
     "php": "~5.5.0|~5.6.0",
     "magento/magento-composer-installer": "*",
-    "magento/framework": "~0.74"
+    "magento/framework": "~1.0.0"
   },
   "extra": {
     "map": [

--- a/sample-module-modifycontent/composer.json
+++ b/sample-module-modifycontent/composer.json
@@ -10,8 +10,8 @@
   "require": {
     "php": "~5.5.0|~5.6.0",
     "magento/magento-composer-installer": "*",
-    "magento/framework": "~0.74",
-    "magento/module-catalog": "~0.74"
+    "magento/framework": "~1.0.0",
+    "magento/module-catalog": "~1.0.0"
   },
   "extra": {
     "map": [

--- a/sample-module-newpage/composer.json
+++ b/sample-module-newpage/composer.json
@@ -9,7 +9,7 @@
   ],
   "require": {
     "php": "~5.5.0|~5.6.0",
-    "magento/framework": "~0.74",
+    "magento/framework": "~1.0.0",
     "magento/magento-composer-installer": "*"
   },
   "extra": {

--- a/sample-module-service-contract-client/composer.json
+++ b/sample-module-service-contract-client/composer.json
@@ -10,8 +10,8 @@
   "require": {
     "php": "~5.5.0|~5.6.0",
     "magento/magento-composer-installer": "*",
-    "magento/framework": "~0.74",
-    "magento/module-catalog": "~0.74"
+    "magento/framework": "~1.0.0",
+    "magento/module-catalog": "~1.0.0"
   },
   "extra": {
     "map": [

--- a/sample-module-service-contract-replacement/composer.json
+++ b/sample-module-service-contract-replacement/composer.json
@@ -10,10 +10,10 @@
   "require": {
     "php": "~5.5.0|~5.6.0",
     "magento/magento-composer-installer": "*",
-    "magento/framework": "~0.74",
-    "magento/module-quote": "~0.74",
-    "magento/module-gift-message": "~0.74",
-    "magento/module-catalog": "~0.74"
+    "magento/framework": "~1.0.0",
+    "magento/module-quote": "~1.0.0",
+    "magento/module-gift-message": "~1.0.0",
+    "magento/module-catalog": "~1.0.0"
   },
   "extra": {
     "map": [

--- a/sample-module-shipping-provider/composer.json
+++ b/sample-module-shipping-provider/composer.json
@@ -10,11 +10,11 @@
   "require": {
     "php": "~5.5.0|~5.6.0",
     "magento/magento-composer-installer": "*",
-    "magento/framework": "~0.74",
-    "magento/module-store": "~0.74",
-    "magento/module-shipping": "~0.74",
-    "magento/module-quote": "~0.74",
-    "magento/module-checkout": "~0.74"
+    "magento/framework": "~1.0.0",
+    "magento/module-store": "~1.0.0",
+    "magento/module-shipping": "~1.0.0",
+    "magento/module-quote": "~1.0.0",
+    "magento/module-checkout": "~1.0.0"
   },
   "extra": {
     "map": [

--- a/sample-module-theme/composer.json
+++ b/sample-module-theme/composer.json
@@ -3,8 +3,8 @@
     "description": "N/A",
     "require": {
         "php": "~5.5.0|~5.6.0",
-        "magento/theme-frontend-luma": "~0.74",
-        "magento/framework": "~0.74",
+        "magento/theme-frontend-luma": "~1.0.0",
+        "magento/framework": "~1.0.0",
         "magento/magento-composer-installer": "*"
     },
     "type": "magento2-theme",

--- a/sample-module-webapi-client/composer.json
+++ b/sample-module-webapi-client/composer.json
@@ -10,7 +10,7 @@
   "require": {
     "php": "~5.5.0|~5.6.0",
     "magento/magento-composer-installer": "*",
-    "magento/module-catalog": "~0.74"
+    "magento/module-catalog": "~1.0.0"
   },
   "extra": {
     "map": [

--- a/sample-module-webflow/composer.json
+++ b/sample-module-webflow/composer.json
@@ -9,7 +9,7 @@
   ],
   "require": {
     "php": "~5.5.0|~5.6.0",
-    "magento/framework": "~0.74",
+    "magento/framework": "~1.0.0",
     "magento/magento-composer-installer": "*"
   },
   "extra": {


### PR DESCRIPTION
This PR updates the Composer referenced dependencies for the magento2-samples to make it work better with Magento 2's recent code updates. They still will require publishing to packages.magento.com.