### PR TITLE
Inject a dummy collection into an UI Form to avoid fatal errors perfo…

### DIFF
--- a/sample-module-form-uicomponent/Model/DataProvider.php
+++ b/sample-module-form-uicomponent/Model/DataProvider.php
@@ -5,11 +5,38 @@
  */
 namespace Magento\SampleForm\Model;
 
+use Magento\Ui\Model\ResourceModel\Bookmark\CollectionFactory;
+
 /**
  * Class DataProvider
  */
 class DataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
 {
+    protected $name;
+    protected $primaryFieldName;
+    protected $requestFieldName;
+    protected $meta;
+    protected $data;
+    protected $collection;
+
+    public function __construct(
+        $name,
+        $primaryFieldName,
+        $requestFieldName,
+        $meta = [],
+        $data = [],
+        CollectionFactory $bookmarkCollectionFactory
+        //IMPORTANT: please notice that we are injecting the class above as a dummy collection due to a bug that forces
+        //data providers to content a valid collection
+    ) {
+        $this->name = $name;
+        $this->primaryFieldName = $primaryFieldName;
+        $this->requestFieldName = $requestFieldName;
+        $this->meta = [];
+        $this->data = [];
+        $this->collection = $bookmarkCollectionFactory->create();
+    }
+
     /**
      * Get data
      *


### PR DESCRIPTION
…ming collection actions

The problem is documented in this issue: https://github.com/magento/magento2-samples/issues/75. 

Also, the main problem is reported here: https://github.com/magento/magento2/issues/13573, with a proposed fix here: https://github.com/magento/magento2/pull/13574

In summary, UI forms' data provider classes can't be declared without a valid collection because collection actions are performed during the execution, and before to display the form, so it will fail with a fatal error. In this case, and if the root problem is not fixed in the core, I'm proposing to inject a dummy collection into the data provider class of the form, avoiding collection methods to crash and keeping stand-alone forms working.

I used the Bookmark class for no particular reasons, just looking for a light and simple collection.